### PR TITLE
break down of income source table

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-
+import pandas as pd
 #
 from policyengine_us import Simulation
 
@@ -18,6 +18,62 @@ def get_net_incomes(state_code, head_employment_income, spouse_employment_income
 
 
 DEFAULT_AGE = 40
+
+
+def get_programs(state_code, head_employment_income, spouse_employment_income=None):
+    # Start by adding the single head.
+    situation = {
+        "people": {
+            "you": {
+                "age": {"2023": DEFAULT_AGE},
+                "employment_income": {"2023": head_employment_income},
+            }
+        }
+    }
+    members = ["you"]
+    if spouse_employment_income is not None:
+        situation["people"]["your partner"] = {
+            "age": {"2023": DEFAULT_AGE},
+            "employment_income": {"2023": spouse_employment_income},
+        }
+        # Add your partner to members list.
+        members.append("your partner")
+    # Create all parent entities.
+    situation["families"] = {"your family": {"members": members}}
+    situation["marital_units"] = {"your marital unit": {"members": members}}
+    situation["tax_units"] = {"your tax unit": {"members": members}}
+    situation["spm_units"] = {"your spm_unit": {"members": members}}
+    situation["households"] = {
+        "your household": {"members": members, "state_name": {"2023": state_code}}
+    }
+
+    simulation = Simulation(situation=situation)
+    household_market_income = int(simulation.calculate( "household_market_income", 2023)[0])
+    household_benefits = int(simulation.calculate("household_benefits", 2023)[0])
+    household_refundable_tax_credits = int(simulation.calculate("household_refundable_tax_credits", 2023)[0])
+    household_refundable_tax_credits = int(simulation.calculate("household_refundable_tax_credits", 2023)[0])
+    household_tax_before_refundable_credits = int(simulation.calculate("household_tax_before_refundable_credits", 2023)[0])
+    snap = int(simulation.calculate( "snap", 2023)[0])
+    school_meal_net_subsidy = int(simulation.calculate("school_meal_net_subsidy", 2023)[0])
+    tanf = int(simulation.calculate("tanf", 2023)[0])
+    spm_unit_wic    = int(simulation.calculate("spm_unit_wic", 2023)[0])
+    medicaid    = int(simulation.calculate("medicaid", 2023)[0])
+    ssi    = int(simulation.calculate("ssi", 2023)[0])
+    eitc = int(simulation.calculate("eitc", 2023)[0])
+    refundable_american_opportunity_credit    = int(simulation.calculate("refundable_american_opportunity_credit", 2023)[0])
+    refundable_ctc    = int(simulation.calculate("refundable_ctc", 2023)[0])
+    recovery_rebate_credit    = int(simulation.calculate("recovery_rebate_credit", 2023)[0])
+    refundable_payroll_tax_credit    = int(simulation.calculate("refundable_payroll_tax_credit", 2023)[0])
+    premium_tax_credit    = int(simulation.calculate("premium_tax_credit", 2023)[0])
+    ecpa_filer_credit    = int(simulation.calculate("ecpa_filer_credit", 2023)[0])
+    ecpa_adult_dependent_credit    = int(simulation.calculate("ecpa_adult_dependent_credit", 2023)[0])
+
+    return [household_market_income ,household_benefits ,household_refundable_tax_credits,household_tax_before_refundable_credits, snap, school_meal_net_subsidy, tanf, spm_unit_wic, medicaid,ssi, eitc, refundable_american_opportunity_credit, refundable_ctc, recovery_rebate_credit, refundable_payroll_tax_credit, premium_tax_credit, ecpa_filer_credit, ecpa_adult_dependent_credit]
+def get_categorized_programs(state_code, head_employment_income, spouse_employment_income):
+     programs_married = get_programs(state_code, head_employment_income, spouse_employment_income)
+     programs_head = get_programs(state_code, head_employment_income)
+     programs_spouse = get_programs(state_code, spouse_employment_income)
+     return [programs_married, programs_head, programs_spouse]
 
 # Create a function to get net income for household
 def get_net_income(state_code, head_employment_income, spouse_employment_income=None):
@@ -50,7 +106,11 @@ def get_net_income(state_code, head_employment_income, spouse_employment_income=
     simulation = Simulation(situation=situation)
 
     return simulation.calculate("household_net_income", 2023)[0]
-
+st.set_page_config(
+    page_title="My Streamlit App",
+    layout="wide",  # or "centered"
+    initial_sidebar_state="expanded"  # or "collapsed"
+)
 
 # Create Streamlit inputs for state code, head income, and spouse income.
 state_code = st.text_input("State Code", "CA")
@@ -61,6 +121,18 @@ spouse_employment_income = st.number_input("Spouse Employment Income", 0)
 net_income_married, net_income_separate = get_net_incomes(
     state_code, head_employment_income, spouse_employment_income
 )
+programs = get_categorized_programs(state_code, head_employment_income, spouse_employment_income)
+married_programs = programs[0]
+head_separate = programs[1]
+spouse_separate = programs[2]
+separate = [x + y for x, y in zip(head_separate, spouse_separate)]
+delta = [abs(x - y) for x, y in zip(married_programs, separate)]
+
+programs = ["household_market_income", "household_benefits", "household_refundable_tax_credits", "household_tax_before_refundable_credits", "snap",
+             "school_meal_net_subsidy", "tanf", "spm_unit_wic", "medicaid", "ssi", "eitc", "refundable_american_opportunity_credit", "refundable_ctc",
+               "recovery_rebate_credit", "refundable_payroll_tax_credit", "premium_tax_credit", "ecpa_filer_credit", "ecpa_adult_dependent_credit",]
+
+
 
 # Determine marriage penalty or bonus, and extent in dollars and percentage.
 marriage_bonus = net_income_married - net_income_separate
@@ -93,3 +165,18 @@ else:
     st.write("You face no marriage penalty or bonus.")
 
 st.write(summarize_marriage_bonus(marriage_bonus))
+# Sample data
+data = {
+    'program': programs,
+    'Joint': married_programs,
+    'Separate': separate,
+    'head_separate': head_separate,
+    'spouse_separate': spouse_separate,
+    'delta (married - separate)': delta
+}
+
+# Create a DataFrame
+#df = pd.DataFrame(data)
+
+# Display the table in Streamlit
+st.table(data)

--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ def get_programs(state_code, head_employment_income, spouse_employment_income=No
     ecpa_filer_credit    = int(simulation.calculate("ecpa_filer_credit", 2023)[0])
     ecpa_adult_dependent_credit    = int(simulation.calculate("ecpa_adult_dependent_credit", 2023)[0])
 
-    return [household_market_income ,household_benefits ,household_refundable_tax_credits,household_tax_before_refundable_credits, snap, school_meal_net_subsidy, tanf, spm_unit_wic, medicaid,ssi, eitc, refundable_american_opportunity_credit, refundable_ctc, recovery_rebate_credit, refundable_payroll_tax_credit, premium_tax_credit, ecpa_filer_credit, ecpa_adult_dependent_credit]
+    return [household_market_income ,household_benefits ,household_refundable_tax_credits,household_tax_before_refundable_credits]
 def get_categorized_programs(state_code, head_employment_income, spouse_employment_income):
      programs_married = get_programs(state_code, head_employment_income, spouse_employment_income)
      programs_head = get_programs(state_code, head_employment_income)
@@ -106,11 +106,11 @@ def get_net_income(state_code, head_employment_income, spouse_employment_income=
     simulation = Simulation(situation=situation)
 
     return simulation.calculate("household_net_income", 2023)[0]
-st.set_page_config(
-    page_title="My Streamlit App",
-    layout="wide",  # or "centered"
-    initial_sidebar_state="expanded"  # or "collapsed"
-)
+# st.set_page_config(
+#     page_title="My Streamlit App",
+#     layout="wide",  # or "centered"
+#     initial_sidebar_state="expanded"  # or "collapsed"
+# )
 
 # Create Streamlit inputs for state code, head income, and spouse income.
 state_code = st.text_input("State Code", "CA")
@@ -126,11 +126,9 @@ married_programs = programs[0]
 head_separate = programs[1]
 spouse_separate = programs[2]
 separate = [x + y for x, y in zip(head_separate, spouse_separate)]
-delta = [abs(x - y) for x, y in zip(married_programs, separate)]
+delta = [x - y for x, y in zip(married_programs, separate)]
 
-programs = ["household_market_income", "household_benefits", "household_refundable_tax_credits", "household_tax_before_refundable_credits", "snap",
-             "school_meal_net_subsidy", "tanf", "spm_unit_wic", "medicaid", "ssi", "eitc", "refundable_american_opportunity_credit", "refundable_ctc",
-               "recovery_rebate_credit", "refundable_payroll_tax_credit", "premium_tax_credit", "ecpa_filer_credit", "ecpa_adult_dependent_credit",]
+programs = ["household_market_income", "household_benefits", "household_refundable_tax_credits", "household_tax_before_refundable_credits"]
 
 
 
@@ -141,7 +139,7 @@ marriage_bonus_percent = marriage_bonus / net_income_married
 
 # Display net incomes in Streamlit.
 st.write("Net Income Married: ", net_income_married)
-st.write("Net Income Separate: ", net_income_separate)
+st.write("Net Income Not Married: ", net_income_separate)
 
 # Display marriage bonus or penalty in Streamlit as a sentence.
 # For example, "You face a marriage [PENALTY/BONUS]"
@@ -167,12 +165,10 @@ else:
 st.write(summarize_marriage_bonus(marriage_bonus))
 # Sample data
 data = {
-    'program': programs,
-    'Joint': married_programs,
-    'Separate': separate,
-    'head_separate': head_separate,
-    'spouse_separate': spouse_separate,
-    'delta (married - separate)': delta
+    'Program': programs,
+    'Married': married_programs,
+    'Not Married': separate,
+    'Delta ': delta
 }
 
 # Create a DataFrame


### PR DESCRIPTION
Here is how it looks in normal width:
![Screenshot 2024-02-20 at 8 36 11 PM](https://github.com/PolicyEngine/us-marriage-incentive/assets/73863365/1ca62064-3391-4e09-b697-f222009b01e5)

Here is the expanded width version to allow all the table to appear:
![Screenshot 2024-02-20 at 8 37 50 PM](https://github.com/PolicyEngine/us-marriage-incentive/assets/73863365/6e0b31b9-c220-4a47-b6c8-3346da26dfe9)

Fixes #13 