### PR TITLE
Add assumptions note to marriage calculator

### DIFF
--- a/src/components/InputForm.jsx
+++ b/src/components/InputForm.jsx
@@ -16,6 +16,12 @@ function clamp(val, min, max) {
   return Math.max(min, Math.min(max, val));
 }
 
+function joinWithAnd(items) {
+  if (items.length <= 1) return items[0] || "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
 const DEFAULT_INCOME = 45000;
 
 export default function InputForm({ country, countries, countryId, onCountryChange, onCalculate, onInputChange, loading, initialValues, externalIncomes }) {
@@ -42,6 +48,18 @@ export default function InputForm({ country, countries, countryId, onCountryChan
   const [errors, setErrors] = useState({});
   const hasMounted = useRef(false);
   const childrenKey = children.map((c) => `${c.age}:${c.isDisabled}`).join(",");
+  const adultInputs = ["age"];
+  if (country.hasDisability) adultInputs.push("disability");
+  if (country.hasPregnancy) adultInputs.push("pregnancy");
+  if (country.hasESI) adultInputs.push("ESI status");
+  const assumptions = [
+    `The calculator uses only the inputs shown here: ${country.regionLabel.toLowerCase()}, year, each adult's wages, ${joinWithAnd(adultInputs)}, and each child's ${country.hasDisability ? "age and disability" : "age"}.`,
+    "Income means wages and salaries only. Unearned income, self-employment income, rent, childcare expenses, deductions, and other omitted income or expense inputs are assumed to be zero.",
+    "For the unmarried comparison, all children are assigned to you and your partner is simulated separately without children.",
+  ];
+  if (country.hasESI) {
+    assumptions.push("If Has ESI is checked, healthcare benefits are excluded from the analysis.");
+  }
 
   // Reset region and defaults when country changes
   const prevCountryId = useRef(country.id);
@@ -181,6 +199,15 @@ export default function InputForm({ country, countries, countryId, onCountryChan
             ))}
           </select>
         </div>
+      </div>
+
+      <div className="sf-assumptions" role="note" aria-label="Model assumptions">
+        <div className="sf-assumptions-title">Assumptions</div>
+        <ul className="sf-assumptions-list">
+          {assumptions.map((assumption) => (
+            <li key={assumption}>{assumption}</li>
+          ))}
+        </ul>
       </div>
 
       <PersonSection

--- a/src/components/InputForm.jsx
+++ b/src/components/InputForm.jsx
@@ -201,15 +201,6 @@ export default function InputForm({ country, countries, countryId, onCountryChan
         </div>
       </div>
 
-      <div className="sf-assumptions" role="note" aria-label="Model assumptions">
-        <div className="sf-assumptions-title">Assumptions</div>
-        <ul className="sf-assumptions-list">
-          {assumptions.map((assumption) => (
-            <li key={assumption}>{assumption}</li>
-          ))}
-        </ul>
-      </div>
-
       <PersonSection
         title="You"
         accent="you"
@@ -304,6 +295,17 @@ export default function InputForm({ country, countries, countryId, onCountryChan
       <button type="submit" className="btn-calc" disabled={loading}>
         {loading ? <><span className="spinner" /> Calculating...</> : "Calculate"}
       </button>
+
+      <details className="sf-assumptions">
+        <summary className="sf-assumptions-summary">Assumptions</summary>
+        <div className="sf-assumptions-body" role="note" aria-label="Model assumptions">
+          <ul className="sf-assumptions-list">
+            {assumptions.map((assumption) => (
+              <li key={assumption}>{assumption}</li>
+            ))}
+          </ul>
+        </div>
+      </details>
     </form>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,19 +227,41 @@ body {
 }
 
 .sf-assumptions {
-  padding: 0.85rem 0.95rem;
   border: 1px solid var(--color-primary-200);
   border-radius: var(--radius-md);
   background: var(--color-primary-50);
+  overflow: hidden;
 }
 
-.sf-assumptions-title {
-  margin-bottom: 0.4rem;
-  font-size: 0.75rem;
+.sf-assumptions-summary {
+  padding: 0.8rem 0.95rem;
+  font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-heading);
+  cursor: pointer;
+  list-style: none;
+}
+
+.sf-assumptions-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sf-assumptions-summary::after {
+  content: "+";
+  float: right;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.sf-assumptions[open] .sf-assumptions-summary::after {
+  content: "\2212";
+}
+
+.sf-assumptions-body {
+  padding: 0 0.95rem 0.9rem;
+  border-top: 1px solid rgba(49, 151, 149, 0.14);
 }
 
 .sf-assumptions-list {
@@ -247,6 +269,7 @@ body {
   color: var(--color-text-muted);
   font-size: 0.8rem;
   line-height: 1.45;
+  margin: 0.7rem 0 0;
 }
 
 .sf-assumptions-list li + li {

--- a/src/styles.css
+++ b/src/styles.css
@@ -226,6 +226,33 @@ body {
   gap: 1rem;
 }
 
+.sf-assumptions {
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--color-primary-200);
+  border-radius: var(--radius-md);
+  background: var(--color-primary-50);
+}
+
+.sf-assumptions-title {
+  margin-bottom: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-heading);
+}
+
+.sf-assumptions-list {
+  padding-left: 1.05rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.sf-assumptions-list li + li {
+  margin-top: 0.35rem;
+}
+
 /* Row of two fields side-by-side */
 .sf-row {
   display: flex;

--- a/tests/design.test.jsx
+++ b/tests/design.test.jsx
@@ -188,7 +188,7 @@ describe("Country toggle", () => {
     expect(yearSelect.options.length).toBe(3);
   });
 
-  it("renders a visible assumptions summary", async () => {
+  it("renders a collapsed assumptions summary", async () => {
     const { default: InputForm } = await import("../src/components/InputForm.jsx");
     const assumptionCountry = {
       ...country,
@@ -198,8 +198,15 @@ describe("Country toggle", () => {
     };
     render(<InputForm country={assumptionCountry} countries={countries} countryId="us" onCountryChange={() => {}} onCalculate={() => {}} loading={false} />);
 
-    const note = screen.getByRole("note", { name: "Model assumptions" });
-    expect(within(note).getByText("Assumptions")).toBeTruthy();
+    const details = document.querySelector(".sf-assumptions");
+    expect(details).toBeTruthy();
+    expect(details.open).toBe(false);
+
+    const summary = within(details).getByText("Assumptions");
+    expect(summary).toBeTruthy();
+    fireEvent.click(summary);
+
+    const note = within(details).getByRole("note", { name: "Model assumptions" });
     expect(within(note).getByText(/wages and salaries only/i)).toBeTruthy();
     expect(within(note).getByText(/all children are assigned to you/i)).toBeTruthy();
     expect(within(note).getByText(/healthcare benefits are excluded from the analysis/i)).toBeTruthy();

--- a/tests/design.test.jsx
+++ b/tests/design.test.jsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import React from "react";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import MetricCards from "../src/components/MetricCards.jsx";
 
 afterEach(cleanup);
@@ -186,5 +186,22 @@ describe("Country toggle", () => {
     expect(yearSelect).toBeTruthy();
     expect(yearSelect.value).toBe("2026");
     expect(yearSelect.options.length).toBe(3);
+  });
+
+  it("renders a visible assumptions summary", async () => {
+    const { default: InputForm } = await import("../src/components/InputForm.jsx");
+    const assumptionCountry = {
+      ...country,
+      hasDisability: true,
+      hasPregnancy: true,
+      hasESI: true,
+    };
+    render(<InputForm country={assumptionCountry} countries={countries} countryId="us" onCountryChange={() => {}} onCalculate={() => {}} loading={false} />);
+
+    const note = screen.getByRole("note", { name: "Model assumptions" });
+    expect(within(note).getByText("Assumptions")).toBeTruthy();
+    expect(within(note).getByText(/wages and salaries only/i)).toBeTruthy();
+    expect(within(note).getByText(/all children are assigned to you/i)).toBeTruthy();
+    expect(within(note).getByText(/healthcare benefits are excluded from the analysis/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- add a visible assumptions note to the marriage calculator sidebar
- clarify that the calculator uses wages/salaries only, treats omitted inputs as zero, and assigns children to the first adult in the unmarried comparison
- add a design test covering the assumptions summary

## Testing
- npx vitest run tests/design.test.jsx
- npm run build

## Notes
- I did not rely on the full `npm test` suite here because `tests/audit-values.test.js` currently shows API-versus-fixture drift unrelated to this UI change.
