### PR TITLE
Wire up Google Analytics 4 and tool_engaged conversion event

### DIFF
--- a/app/MarriageApp.jsx
+++ b/app/MarriageApp.jsx
@@ -127,6 +127,23 @@ export default function MarriageApp({ initialCountry = null }) {
     setMounted(true);
   }, [initialCountry]);
 
+  // Fire the tool_engaged conversion event after the user has been on
+  // the page long enough to count as genuinely engaged. Matches the
+  // 15-second threshold and event shape used by policyengine-app-v2's
+  // AppClient so these conversions feed into the same GA4/Google Ads
+  // reporting as the other tools.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (typeof window !== "undefined" && window.gtag) {
+        window.gtag("event", "tool_engaged", {
+          tool_name: "marriage",
+          tool_title: "Marriage Tax Calculator",
+        });
+      }
+    }, 15000);
+    return () => clearTimeout(timer);
+  }, []);
+
   // Swap favicon for valentine mode
   useEffect(() => {
     const link = document.querySelector('link[rel="icon"]');

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 const inter = Inter({
@@ -9,6 +10,11 @@ const inter = Inter({
 
 const SITE_URL = "https://policyengine.org/us/marriage";
 const OG_IMAGE = "https://policyengine.org/us/marriage/og-image.png";
+
+// Matches the GA4 property used by policyengine-app-v2/website so
+// page_view and tool_engaged events from this calculator land in the
+// same account as the rest of policyengine.org traffic.
+const GA_MEASUREMENT_ID = "G-2YHG89FY0N";
 
 // Paths referenced in <head> must be explicitly prefixed — Next does not apply
 // basePath to metadata.icons values the way it does for <Image> or <Link>.
@@ -68,6 +74,21 @@ const STRUCTURED_DATA = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className={inter.className}>
+      <head>
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            window.gtag = gtag;
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}');
+          `}
+        </Script>
+      </head>
       <body>
         {children}
         <script


### PR DESCRIPTION
## The bug

This app has been serving `/us/marriage` on policyengine.org since the Vercel rewrite was added (#105) but **never had any analytics setup**. Page views don't fire, `tool_engaged` doesn't fire, and Google Ads has been reporting **zero conversions** from every keyword that lands here since the rewrite went live.

## Evidence

Headless test showed `window.gtag` undefined and zero tracking beacons on `/us/marriage` while every other calculator page (e.g. `/us/aca-reforms-calculator`) had working tracking. Reported CvR on the top 3 keywords landing here (`marriage tax calculator`, `filing jointly vs separately`, `married vs single tax calculator`) collapsed from 65–72% to 0% around the time the rewrite was deployed — consistent with silent tracking loss rather than any drop in actual engagement.

## The fix

Match what `policyengine-app-v2/website/src/app/layout.tsx` and `AppClient.tsx` already do:

- **`app/layout.jsx`** — add the GA4 bootstrap (gtag.js + config) in `<head>` using the same `G-2YHG89FY0N` property so conversions aggregate with the rest of policyengine.org. Uses `next/script` with `afterInteractive` so it doesn't block hydration.

- **`app/MarriageApp.jsx`** — fire `tool_engaged` after 15 seconds on page, matching the threshold and event shape used by the main app's `AppClient.tsx`. Passes `tool_name="marriage"` and `tool_title="Marriage Tax Calculator"`.

## Test plan

After deploy:
- [ ] Open `https://policyengine.org/us/marriage` in a fresh tab. Chrome DevTools → Network. Confirm `/gtag/js` loads and `/g/collect` fires with `en=page_view`.
- [ ] Wait 15 seconds on the page. Confirm a second `/g/collect` fires with `en=tool_engaged`, `ep.tool_name=marriage`.
- [ ] Check Google Analytics Realtime → ensure the marriage page appears alongside other tools.
- [ ] Within 24–48 hours, check Google Ads → Campaigns → `PolicyEngine: US` → the marriage-family keywords should start showing conversions again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)