### PR TITLE
Import @policyengine/ui-kit/theme.css for brand tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,4 @@
+@import "@policyengine/ui-kit/theme.css";
 * {
   box-sizing: border-box;
   margin: 0;


### PR DESCRIPTION
PolicyEngineShell header uses `--color-teal-*` and `--spacing-header` from theme.css. Without these tokens the gradient renders blank.