### PR TITLE
Inline PE brand tokens (marriage has no Tailwind v4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Thumbs.db
 .next/
 out/
 next-env.d.ts
+.vercel
+.env*.local

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,20 @@
-@import "@policyengine/ui-kit/theme.css";
+:root {
+  /* PolicyEngine brand tokens (inlined since marriage doesn't have Tailwind v4) */
+  --color-teal-50: #E6FFFA;
+  --color-teal-100: #B2F5EA;
+  --color-teal-200: #81E6D9;
+  --color-teal-300: #4FD1C5;
+  --color-teal-400: #38B2AC;
+  --color-teal-500: #319795;
+  --color-teal-600: #2C7A7B;
+  --color-teal-700: #285E61;
+  --color-teal-800: #234E52;
+  --color-teal-900: #1D4044;
+  --text-inverse: #FFFFFF;
+  --spacing-header: 58px;
+  --font-sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;

--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -31,9 +31,14 @@
       "label": "reduced price school meals"
     },
     {
-      "variable": "spm_unit_broadband_subsidy",
+      "variable": "acp",
       "entity": "spm_unit",
-      "label": "SPM unit broadband subsidy"
+      "label": "Affordable Connectivity Program"
+    },
+    {
+      "variable": "ebb",
+      "entity": "spm_unit",
+      "label": "Emergency Broadband Benefit amount"
     },
     {
       "variable": "tanf",
@@ -138,6 +143,16 @@
       "variable": "household_state_tax_before_refundable_credits",
       "entity": "household",
       "label": "household State tax before refundable credits"
+    },
+    {
+      "variable": "local_income_tax_before_refundable_credits",
+      "entity": "tax_unit",
+      "label": "Local income tax before refundable credits"
+    },
+    {
+      "variable": "local_occupational_tax",
+      "entity": "tax_unit",
+      "label": "Local occupational tax"
     }
   ],
   "healthcare": [
@@ -152,9 +167,9 @@
       "label": "Average CHIP payment"
     },
     {
-      "variable": "aca_ptc",
+      "variable": "assigned_aca_ptc",
       "entity": "tax_unit",
-      "label": "ACA premium tax credit for tax unit"
+      "label": "Assigned ACA premium tax credit for tax unit"
     },
     {
       "variable": "co_omnisalud",
@@ -522,6 +537,11 @@
         "label": "NE EITC amount"
       },
       {
+        "variable": "ne_stillborn_credit",
+        "entity": "tax_unit",
+        "label": "Nebraska stillborn child tax credit"
+      },
+      {
         "variable": "ne_refundable_ctc",
         "entity": "tax_unit",
         "label": "Nebraska refundable Child Tax Credit"
@@ -650,6 +670,11 @@
         "variable": "or_ctc",
         "entity": "tax_unit",
         "label": "Oregon Child Tax Credit"
+      },
+      {
+        "variable": "or_529_credit",
+        "entity": "tax_unit",
+        "label": "Oregon 529 plan contribution credit"
       },
       {
         "variable": "or_working_family_household_and_dependent_care_credit",


### PR DESCRIPTION
theme.css import requires Tailwind v4 (tw-animate-css, @custom-variant). Marriage uses plain CSS — inline just the brand tokens needed by PolicyEngineShell.